### PR TITLE
fix: Bump patch version, to match tag.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.5)
 # Note: Always keep MAJOR_VERSION and MINOR_VERSION identical to the server version. Count only the patch separately.
 set(${PROJECT_NAME}_MAJOR_VERSION 01)
 set(${PROJECT_NAME}_MINOR_VERSION 00)
-set(${PROJECT_NAME}_PATCH_VERSION 02)
+set(${PROJECT_NAME}_PATCH_VERSION 03)
 include(cmake/set_version_numbers.cmake)
 
 include(cmake/config_generator_project.cmake)


### PR DESCRIPTION
The last bump was for some reason from 01.00.01 to 01.00.02, even though a tag for 1.0.2 already existed. I forgot to make a new release tag, why the package was using the wrong commit (from the previous tag). To fix this, I bumped the version to 1.0.3, make a release tag and build a new package from there.